### PR TITLE
Add missing dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,9 @@ Imports:
     stringi,
     cowplot,
     readxl,
-    HGNChelper
+    HGNChelper,
+    ggdendro,
+    gridExtra
 Suggests: knitr, BiocStyle
 biocViews: GeneExpression, Transcription, DifferentialExpression,
         GeneSetEnrichment, Genetics, Microarray,


### PR DESCRIPTION
Without these additions, package fails to install on a fresh Docker
image of rocker/rstudio:3.6.1.